### PR TITLE
chore: update model name to gemini-2.0-flash

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,13 +1,11 @@
 # BACKLOG
 
-- switch to google.golang.org/genai // go get https://github.com/googleapis/go-genai
-
+- clean up logging, make tighter, cleaner, no emojis
+    - remove verbose option too -- just always be maximally verbose
 - fix: when a glance file regenerates, *all* glance files in *all* of its parent directories need to regenerate
 - create post-commit hook to run glance
 - improve performance -- make *fast*
 - timestamp generated glance files
-- clean up logging, make tighter, cleaner, no emojis
-- remove verbose option -- just always be maximally verbose
 - remove force option
 - audit whole codebase against dev philosophy, identify key things to hit
 - refactor aggressively

--- a/glance.go
+++ b/glance.go
@@ -110,7 +110,7 @@ func createLLMService(cfg *config.Config) (llm.Client, *llm.Service, error) {
 	// Create the client with functional options
 	client, err := llm.NewGeminiClient(
 		cfg.APIKey,
-		llm.WithModelName("gemini-2.5-flash-preview-04-17"),
+		llm.WithModelName("gemini-2.0-flash"),
 		llm.WithMaxRetries(cfg.MaxRetries),
 		llm.WithTimeout(60),
 	)

--- a/llm/client.go
+++ b/llm/client.go
@@ -138,7 +138,7 @@ type ClientOptions struct {
 func DefaultClientOptions() ClientOptions {
 	return ClientOptions{
 		// Basic configuration
-		ModelName:  "gemini-2.5-flash-preview-04-17",
+		ModelName:  "gemini-2.0-flash",
 		MaxRetries: 3,
 		Timeout:    60, // 60 seconds
 

--- a/llm/client_test.go
+++ b/llm/client_test.go
@@ -117,7 +117,7 @@ func TestClientInterface(t *testing.T) {
 func TestClientOptions(t *testing.T) {
 	// Test default options
 	options := DefaultClientOptions()
-	assert.Equal(t, "gemini-2.5-flash-preview-04-17", options.ModelName)
+	assert.Equal(t, "gemini-2.0-flash", options.ModelName)
 	assert.Greater(t, options.MaxRetries, 0)
 	assert.Greater(t, options.Timeout, 0)
 

--- a/llm/service.go
+++ b/llm/service.go
@@ -42,7 +42,7 @@ type ServiceConfig struct {
 func DefaultServiceConfig() ServiceConfig {
 	return ServiceConfig{
 		MaxRetries:     3,
-		ModelName:      "gemini-2.5-flash-preview-04-17", // Make sure this matches the client default
+		ModelName:      "gemini-2.0-flash", // Make sure this matches the client default
 		Verbose:        false,
 		PromptTemplate: "",
 	}

--- a/mock_test.go
+++ b/mock_test.go
@@ -46,14 +46,14 @@ func TestMockExample(t *testing.T) {
 	mockClient := new(MockGeminiClient)
 
 	// Set up expectations
-	mockClient.On("GenerativeModel", "gemini-2.5-flash-preview-04-17").Return(mockClient)
+	mockClient.On("GenerativeModel", "gemini-2.0-flash").Return(mockClient)
 	mockClient.On("CountTokens", mock.Anything, mock.Anything).Return(map[string]interface{}{
 		"TotalTokens": int32(100),
 	})
 	mockClient.On("Close").Return(nil)
 
 	// Example usage
-	model := mockClient.GenerativeModel("gemini-2.5-flash-preview-04-17")
+	model := mockClient.GenerativeModel("gemini-2.0-flash")
 	assert.NotNil(t, model, "Should return a mock model")
 
 	tokenResponse := mockClient.CountTokens(context.Background(), "test prompt")


### PR DESCRIPTION
## Summary
- Updates all references to `gemini-2.5-flash-preview-04-17` to use `gemini-2.0-flash` instead
- Reorganizes tasks in BACKLOG.md to reflect completed genai migration
- Ensures all tests pass with the new model name

## Test plan
- Ran client tests: `go test ./llm -run=TestClientOptions`
- Ran mock tests: `go test ./... -run=TestMockExample`
- All pre-commit checks pass