### PR TITLE
fix: prevent pre-commit hooks from blocking PR merges

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -157,9 +157,10 @@ repos:
         exclude: '^precommit-tests/test_private_key.txt$|^vendor/'
 
       - id: no-commit-to-branch
-        name: Prevent commits to main branch
-        description: Prevents direct commits to the main branch
+        name: Prevent direct commits to protected branches
+        description: Prevents direct commits to protected branches (still allows merges)
         args: [--branch, main, --branch, master]
+        stages: [commit]  # Only run during regular commits, not during merges
 
   # Optimized secrets detection
   - repo: https://github.com/Yelp/detect-secrets

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -160,7 +160,7 @@ repos:
         name: Prevent direct commits to protected branches
         description: Prevents direct commits to protected branches (still allows merges)
         args: [--branch, main, --branch, master]
-        stages: [commit]  # Only run during regular commits, not during merges
+        stages: [pre-commit]  # Only run during regular commits, not during merges
 
   # Optimized secrets detection
   - repo: https://github.com/Yelp/detect-secrets


### PR DESCRIPTION
## Summary
- Fixes issue where PR merges to master were being blocked by the no-commit-to-branch pre-commit hook
- Configures the hook to only run during pre-commit stage, not during merge commits
- Updates to use non-deprecated stage names via pre-commit migrate-config

## Test plan
- Verify successful PR merges to master branch after this change is applied