### PR TITLE
fix: skip LLM for empty directories, write minimal stub instead

### DIFF
--- a/empty_directory_test.go
+++ b/empty_directory_test.go
@@ -43,6 +43,9 @@ func TestEmptyDirectorySkipsLLM(t *testing.T) {
 		assert.NoError(t, r.err)
 		mockLLMClient.AssertNotCalled(t, "Generate", mock.Anything, mock.Anything)
 
+		// Assert: attempts == 1 so BubbleUpParents fires and parent dirs get regenerated
+		assert.Equal(t, 1, r.attempts, "stub path must set attempts=1 to trigger parent propagation")
+
 		// Assert: stub file written with minimal honest content
 		glancePath := filepath.Join(dir, filesystem.GlanceFilename)
 		require.FileExists(t, glancePath)

--- a/glance.go
+++ b/glance.go
@@ -422,7 +422,7 @@ func processDirectory(dir string, forceDir bool, ignoreChain filesystem.IgnoreCh
 			return r
 		}
 		r.success = true
-		r.attempts = 0
+		r.attempts = 1 // Counts as processed: triggers BubbleUpParents for parent regen
 		return r
 	}
 


### PR DESCRIPTION
## Summary

Closes #61

When `glance` runs on an empty directory, it had no file content to send to the LLM — only the directory path name. The LLM would hallucinate plausible-sounding framework details from the path alone (e.g., inventing Rails/Sprockets documentation for a Next.js project's `lib/assets` directory). A confidently wrong summary is worse than no summary: agents and developers reading `.glance.md` treat it as ground truth.

This fix detects the empty-content case before invoking the LLM and writes a minimal honest stub instead: `# <dirname>\n\nEmpty directory.\n`.

## Changes

- **`glance.go`** — Added early-return branch in `processDirectory`: if `fileContents` is empty and `subGlances` is blank (no child summaries bubbled up), write a one-line stub via `os.WriteFile` using the existing `ValidateFilePath` security boundary, then return `success=true` without touching the LLM.
- **`empty_directory_test.go`** — New test file with two cases:
  - `TestEmptyDirectorySkipsLLM/empty directory writes stub without calling LLM`: asserts LLM mock is never called, stub file exists, contains "Empty directory".
  - `TestEmptyDirectorySkipsLLM/directory with only subglances still calls LLM`: asserts that a directory with no local files but *with* child `.glance.md` summaries still reaches the LLM (child context is meaningful).

## Acceptance Criteria

- [x] Empty directories produce a minimal stub (not a hallucinated summary)
- [x] The LLM is never called when there is nothing to analyze
- [x] Directories with child summaries but no local files still call the LLM
- [x] Security path validation still runs before writing the stub
- [x] All existing tests continue to pass with `-race`

## Manual QA

```bash
# Build
go build -o glance

# Create a deeply nested empty directory tree
mkdir -p /tmp/hallucination-test/lib/assets

# Run glance
GEMINI_API_KEY=<your-key> ./glance /tmp/hallucination-test

# Inspect the stub — should be minimal, NOT mention Rails/Sprockets/Next.js
cat /tmp/hallucination-test/lib/assets/.glance.md
# Expected:
# # assets
#
# Empty directory.

# Inspect root (has child summaries, so LLM runs)
cat /tmp/hallucination-test/.glance.md
# Should be LLM-generated, referencing child summaries

# Cleanup
rm -rf /tmp/hallucination-test
```

## What Changed

```mermaid
stateDiagram-v2
    state "Before" as B {
        [*] --> GatherFiles
        GatherFiles --> CheckContent
        CheckContent --> CallLLM : always
        CallLLM --> WriteGlance
        WriteGlance --> [*]
        note right of CallLLM : Empty dir → LLM hallucinates\nfrom path name alone
    }

    state "After" as A {
        [*] --> GatherFiles2
        GatherFiles2 --> CheckContent2
        CheckContent2 --> WriteStub : no files & no child summaries
        CheckContent2 --> CallLLM2 : has content or child summaries
        WriteStub --> [*]
        CallLLM2 --> WriteGlance2
        WriteGlance2 --> [*]
        note right of WriteStub : Honest stub:\n"Empty directory."
    }
```

## Before / After

**Before:** Running `glance` on `lib/assets` (an empty directory in a Next.js project) produced:

> *"The /lib/assets directory follows the conventional Rails Asset Pipeline (Sprockets) structure, segregating resources by type into subdirectories such as stylesheets, javascripts, and images... `config.assets.precompile`, Rails Engines, `sassc-rails`..."*

No Rails code exists in the project. The LLM invented everything from the path name.

**After:** The same directory produces:

```markdown
# assets

Empty directory.
```

No LLM call is made. No hallucination possible.

## Test Coverage

- `empty_directory_test.go` — `TestEmptyDirectorySkipsLLM`
  - Case 1: empty dir → stub written, `Generate` never called (asserted via mock)
  - Case 2: dir with child summaries → `Generate` called (existing LLM path preserved)

Gap: no integration test against a real LLM. The mock approach is sufficient given the logic is pre-LLM gating, not LLM behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Directories with no analyzable content now skip unnecessary LLM processing and write appropriate stub files instead.
  * Improved handling of edge cases such as directories containing only binary or hidden files.

* **Tests**
  * Added comprehensive test suite for empty and edge-case directory scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->