### PR TITLE
chore(release): configure Landfall manifest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,10 +34,11 @@ jobs:
           persist-credentials: false
 
       - name: Run Landfall
-        uses: misty-step/landfall@e991bd36d85efd957225d384643b0ecc582176bf # v1
+        uses: misty-step/landfall@90249a366099e6a5f66b081de24359c5b3cbf506 # v1.23.0
         with:
           github-token: ${{ secrets.GH_RELEASE_TOKEN }}
           llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}
           synthesis: "true"
+          healthcheck: "true"
           audience: developer
           node-version: "22"

--- a/.landfall.yml
+++ b/.landfall.yml
@@ -1,0 +1,23 @@
+product:
+  name: Glance
+  description: "Command-line tool that recursively scans a directory tree and writes glance.md summaries in each directory using an LLM pipeline with retries, backoff, provider failover, and safe file handling."
+audience: developer
+voice: clear, concrete, and specific to shipped CLI behavior
+changelog:
+  source: auto
+artifacts:
+  markdown: docs/releases/{version}.md
+  plaintext: null
+  html: null
+  json: docs/releases/releases.json
+  rss: null
+release:
+  profile: full
+model:
+  policy: balanced
+  primary: null
+  fallbacks: []
+budget:
+  max_input_tokens: 12000
+  max_output_tokens: 1200
+  max_usd: null


### PR DESCRIPTION
## Summary

Adds Glance-specific Landfall context and advances the existing pinned Landfall release action to v1.23.0.

## Changes

- Adds `.landfall.yml` with product description, voice, artifact, model, and budget defaults.
- Updates the existing Landfall action pin to `90249a366099e6a5f66b081de24359c5b3cbf506` (`v1.23.0`).
- Enables Landfall `healthcheck` before release-note synthesis.

## Verification

- `landfall manifest-defaults --repo-root /tmp/landfall-dogfood-downstream/glance`
- `actionlint .github/workflows/release.yml`
- `git diff --check`
- `go test -race ./... -run '^$'`
- `go test -race ./config ./errors ./filesystem ./llm ./ui`
- Fresh adversarial review: no blocking findings after clarifying the existing full release mode.

## Local caveat

`go test -race ./...` is blocked on this macOS host because the local pinned `govulncheck` binary aborts with `missing LC_UUID load command`, and rebuilding `govulncheck@v1.1.3` fails under Go 1.26. Hosted CI should verify the full pinned-tool path on Ubuntu.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added release configuration for the Glance product, including structured release notes output and changelog generation settings.

* **Bug Fixes**
  * Updated the release workflow to use a newer release action version and enabled health checks during the release step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->