### PR TITLE
ci(release): pin Landfall v1.23.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
           persist-credentials: false
 
       - name: Run Landfall
-        uses: misty-step/landfall@90249a366099e6a5f66b081de24359c5b3cbf506 # v1.23.0
+        uses: misty-step/landfall@46cd9f6c0dad62210ce61601a1b65a3e15e2e0d6 # v1.23.1
         with:
           github-token: ${{ secrets.GH_RELEASE_TOKEN }}
           llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}


### PR DESCRIPTION
## Summary
Update Glance's Landfall action pin from v1.23.0 to v1.23.1 so the release workflow picks up the no-release summary artifact fix found during dogfood.

## Changes
- Updated `.github/workflows/release.yml` to pin `misty-step/landfall` at `46cd9f6c0dad62210ce61601a1b65a3e15e2e0d6 # v1.23.1`.
- Preserved workflow triggers, permissions, checkout settings, and Landfall inputs.

## Test coverage
- `/Users/phaedrus/Development/landfall/target/debug/landfall manifest-defaults`
- `actionlint .github/workflows/release.yml`
- `git diff --check`
- `go test -race ./... -run '^$'`
- `go test -race ./config ./errors ./filesystem ./llm ./ui`

## Manual QA
- Verified Landfall `v1.23.1`, floating `v1`, and the pinned SHA all point to `46cd9f6c0dad62210ce61601a1b65a3e15e2e0d6` before updating this workflow.
- Fresh-context release-workflow review returned no blocking findings and confirmed no trigger, permission, checkout, or input drift.
- Full local `go test -race ./...` is still blocked by the local macOS `govulncheck` binary aborting with `missing LC_UUID load command`; hosted CI is the authoritative full-suite check for this environment-specific failure.
